### PR TITLE
Use SPDX identifier in license field of META.info

### DIFF
--- a/META.info
+++ b/META.info
@@ -10,7 +10,7 @@
     "Unicode::PRECIS"
   ],
   "description": "Salted Challenge Response Authentication Mechanism (SCRAM)",
-  "license": "The Artistic License 2.0",
+  "license": "Artistic-2.0",
   "name": "Auth::SCRAM",
   "perl": "6.c",
   "provides": {


### PR DESCRIPTION
Use the standardized identifier for the license field.
For more details see https://design.perl6.org/S22.html#license